### PR TITLE
Feat: 유저 삭제 비지니스 로직

### DIFF
--- a/src/main/java/com/example/twentyfiveframes/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     }
 
     // 탈퇴
-    @DeleteMapping("/users/delete")
+    @DeleteMapping("/users")
     public ResponseEntity<Void> delete(@Valid @RequestBody AuthRequestDto.passwordConfirm dto, @AuthenticationPrincipal Long userId) {
         authService.delete(userId, dto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/com/example/twentyfiveframes/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/controller/AuthController.java
@@ -8,10 +8,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping
@@ -30,5 +28,12 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponseDto.Login> login(@Valid @RequestBody AuthRequestDto.Login login) {
         return ResponseEntity.status(HttpStatus.OK).body(authService.login(login));
+    }
+
+    // 탈퇴
+    @DeleteMapping("/users/delete")
+    public ResponseEntity<Void> delete(@Valid @RequestBody AuthRequestDto.passwordConfirm dto, @AuthenticationPrincipal Long userId) {
+        authService.delete(userId, dto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/example/twentyfiveframes/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/dto/AuthRequestDto.java
@@ -39,4 +39,12 @@ public class AuthRequestDto {
         @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
         private final String password;
     }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class CheckPw {
+
+        @NotBlank (message = "비밀번호는 필수 입력 항목입니다.")
+        private final String password;
+    }
 }

--- a/src/main/java/com/example/twentyfiveframes/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/dto/AuthRequestDto.java
@@ -42,7 +42,7 @@ public class AuthRequestDto {
 
     @Getter
     @RequiredArgsConstructor
-    public static class CheckPw {
+    public static class passwordConfirm {
 
         @NotBlank (message = "비밀번호는 필수 입력 항목입니다.")
         private final String password;

--- a/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthService.java
@@ -11,4 +11,7 @@ public interface AuthService {
 
     // 로그인
     AuthResponseDto.Login login(AuthRequestDto.Login loginRequest);
+
+    // 탈퇴
+    void delete(Long userId, AuthRequestDto.CheckPw dto);
 }

--- a/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthService.java
@@ -13,5 +13,5 @@ public interface AuthService {
     AuthResponseDto.Login login(AuthRequestDto.Login loginRequest);
 
     // 탈퇴
-    void delete(Long userId, AuthRequestDto.CheckPw dto);
+    void delete(Long userId, AuthRequestDto.passwordConfirm dto);
 }

--- a/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.twentyfiveframes.domain.auth.dto.AuthRequestDto;
 import com.example.twentyfiveframes.domain.auth.dto.AuthResponseDto;
 import com.example.twentyfiveframes.domain.user.dto.UserRequestDto;
 import com.example.twentyfiveframes.domain.user.dto.UserResponseDto;
+import com.example.twentyfiveframes.domain.user.entity.User;
 import com.example.twentyfiveframes.domain.user.service.UserService;
 import com.example.twentyfiveframes.security.JwtService;
 import lombok.RequiredArgsConstructor;
@@ -56,8 +57,12 @@ public class AuthServiceImpl implements AuthService {
 
     // 탈퇴
     @Override
-    public void delete(Long userId, AuthRequestDto.CheckPw dto) {
-
+    public void delete(Long userId, AuthRequestDto.passwordConfirm dto) {
+        User user = userService.getUserByUserId(userId);
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+        }
+        userService.deleteByUserId(userId);
     }
 
 

--- a/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/auth/service/AuthServiceImpl.java
@@ -51,4 +51,14 @@ public class AuthServiceImpl implements AuthService {
 
         return new AuthResponseDto.Login(accessToken, "Bearer " + refreshToken);
     }
+
+    // 로그아웃
+
+    // 탈퇴
+    @Override
+    public void delete(Long userId, AuthRequestDto.CheckPw dto) {
+
+    }
+
+
 }

--- a/src/main/java/com/example/twentyfiveframes/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/user/dto/UserResponseDto.java
@@ -23,7 +23,7 @@ public class UserResponseDto {
         private final String name;
         private final String userType;
 
-//        @JsonFormat(pattern = "yyyy-MM-dd")
+        @JsonFormat(pattern = "yyyy-MM-dd")
         private final LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/example/twentyfiveframes/domain/user/entity/User.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/user/entity/User.java
@@ -4,9 +4,13 @@ import com.example.twentyfiveframes.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE movie_db.user SET deleted_at = now() WHERE id = ?")
+@SQLRestriction("deleted_at is null")
 @NoArgsConstructor
 public class User extends BaseEntity {
 

--- a/src/main/java/com/example/twentyfiveframes/domain/user/service/UserService.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/user/service/UserService.java
@@ -17,4 +17,7 @@ public interface UserService {
 
     // user 정보 조회
     UserResponseDto.Get get(Long userId);
+
+    // user 삭제
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/twentyfiveframes/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/twentyfiveframes/domain/user/service/UserServiceImpl.java
@@ -55,4 +55,9 @@ public class UserServiceImpl implements UserService {
                 user.getRole().toString(),
                 user.getCreatedAt());
     }
+
+    @Override
+    public void deleteByUserId(Long userId) {
+        userRepository.deleteById(userId);
+    }
 }


### PR DESCRIPTION
## #️⃣이슈 번호 
- ex) close #번호

close #36 


## 📝작업 상세 내용

- [ ] UserService 삭제 메서드 추가
- [ ] User Entity SQL 어노테이션 추가
- [ ] Jpa delete 메서드 수정
- [ ] AuthConteroller 삭제 메서드 추가
- [ ] AuthService 비밀번호 검증 메서드 추가


## 💬리뷰 요구사항 (선택)
- 머지 이후에 user 구조를 바꾸는 작업을 진행할 예정입니다.
- 비지니스 로직 부분과 섞이면 좋지 않을 듯하여 완성된 코드만 올렸습니다.
